### PR TITLE
feat: animated SVG weather icons for weather display action (issue #36)

### DIFF
--- a/src/plugin/actions/weatherDisplay.ts
+++ b/src/plugin/actions/weatherDisplay.ts
@@ -6,7 +6,8 @@ import { homeAssistantClient } from "../services/homeAssistant";
 import { cacheManager } from "../state/cache";
 import { BaseAction } from "./base";
 import { ActionType } from "../../shared/actionTypes";
-import { formatWeatherTitle } from "./weatherUtils";
+import { getWeatherAnimationSvg } from "../utils/weatherAnimations";
+import { formatTemperatureLabel } from "./weatherUtils";
 
 @action({ UUID: ActionType.WEATHER_DISPLAY })
 export class WeatherDisplayAction extends BaseAction {
@@ -18,14 +19,14 @@ export class WeatherDisplayAction extends BaseAction {
     protected override async handleWillAppear(ev: WillAppearEvent<ActionSettings>): Promise<void> {
         const entityId = ev.payload.settings?.entityId;
         if (entityId) {
-            await this.updateTitle(entityId);
+            await this.updateImage(entityId);
         }
     }
 
     protected override async handleSettingsChanged(ev: DidReceiveSettingsEvent<ActionSettings>): Promise<void> {
         const entityId = ev.payload.settings?.entityId;
         if (entityId) {
-            await this.updateTitle(entityId);
+            await this.updateImage(entityId);
         }
     }
 
@@ -37,13 +38,16 @@ export class WeatherDisplayAction extends BaseAction {
             return;
         }
 
-        const title = formatWeatherTitle(newState);
+        const svg = getWeatherAnimationSvg(newState.state, formatTemperatureLabel(newState));
         await Promise.all(
-            matchingContexts.map(([, context]) => context.action.setTitle(title)),
+            matchingContexts.map(([, context]) => Promise.all([
+                context.action.setImage(svg),
+                context.action.setTitle(""),
+            ])),
         );
     }
 
-    private async updateTitle(entityId: string): Promise<void> {
+    private async updateImage(entityId: string): Promise<void> {
         const entity = cacheManager.getEntity(entityId);
         if (!entity) {
             logMessage(`WeatherDisplayAction: no cached state for ${entityId}`);
@@ -54,9 +58,12 @@ export class WeatherDisplayAction extends BaseAction {
             ([, context]) => context.settings.entityId === entityId,
         );
 
-        const title = formatWeatherTitle(entity);
+        const svg = getWeatherAnimationSvg(entity.state, formatTemperatureLabel(entity));
         await Promise.all(
-            matchingContexts.map(([, context]) => context.action.setTitle(title)),
+            matchingContexts.map(([, context]) => Promise.all([
+                context.action.setImage(svg),
+                context.action.setTitle(""),
+            ])),
         );
     }
 }

--- a/src/plugin/actions/weatherDisplay.ts
+++ b/src/plugin/actions/weatherDisplay.ts
@@ -1,4 +1,5 @@
-import { action, DidReceiveSettingsEvent, WillAppearEvent } from "@elgato/streamdeck";
+import { action, DidReceiveSettingsEvent, WillAppearEvent, WillDisappearEvent } from "@elgato/streamdeck";
+import type { KeyAction } from "@elgato/streamdeck";
 
 import type { ActionSettings, HomeAssistantEntity } from "../../shared/types";
 import { logMessage } from "../logging";
@@ -6,27 +7,42 @@ import { homeAssistantClient } from "../services/homeAssistant";
 import { cacheManager } from "../state/cache";
 import { BaseAction } from "./base";
 import { ActionType } from "../../shared/actionTypes";
-import { getWeatherAnimationSvg } from "../utils/weatherAnimations";
+import { getWeatherFrames, WEATHER_FRAME_INTERVAL_MS } from "../utils/weatherAnimations";
 import { formatTemperatureLabel } from "./weatherUtils";
+
+interface AnimationState {
+    frames: string[];
+    frameIndex: number;
+    timer: NodeJS.Timeout;
+}
 
 @action({ UUID: ActionType.WEATHER_DISPLAY })
 export class WeatherDisplayAction extends BaseAction {
+    private readonly animations = new Map<string, AnimationState>();
+
     constructor() {
         super();
         homeAssistantClient.on("stateChanged", (entityId, state) => this.handleStateChange(entityId, state));
     }
 
     protected override async handleWillAppear(ev: WillAppearEvent<ActionSettings>): Promise<void> {
+        if (!ev.action.isKey()) return;
         const entityId = ev.payload.settings?.entityId;
         if (entityId) {
-            await this.updateImage(entityId);
+            await this.startAnimation(ev.action.id, ev.action, entityId);
         }
     }
 
+    protected override handleWillDisappear(ev: WillDisappearEvent<ActionSettings>): void {
+        this.stopAnimation(ev.action.id);
+    }
+
     protected override async handleSettingsChanged(ev: DidReceiveSettingsEvent<ActionSettings>): Promise<void> {
+        if (!ev.action.isKey()) return;
         const entityId = ev.payload.settings?.entityId;
+        this.stopAnimation(ev.action.id);
         if (entityId) {
-            await this.updateImage(entityId);
+            await this.startAnimation(ev.action.id, ev.action, entityId);
         }
     }
 
@@ -34,37 +50,53 @@ export class WeatherDisplayAction extends BaseAction {
         const matchingContexts = Array.from(this.getAllContexts()).filter(
             ([, context]) => context.settings.entityId === entityId,
         );
-        if (matchingContexts.length === 0) {
-            return;
+        for (const [contextId, context] of matchingContexts) {
+            this.stopAnimation(contextId);
+            await this.startAnimationForEntity(contextId, context.action, newState);
         }
-
-        const svg = getWeatherAnimationSvg(newState.state, formatTemperatureLabel(newState));
-        await Promise.all(
-            matchingContexts.map(([, context]) => Promise.all([
-                context.action.setImage(svg),
-                context.action.setTitle(""),
-            ])),
-        );
     }
 
-    private async updateImage(entityId: string): Promise<void> {
+    private async startAnimation(contextId: string, action: KeyAction<ActionSettings>, entityId: string): Promise<void> {
         const entity = cacheManager.getEntity(entityId);
         if (!entity) {
             logMessage(`WeatherDisplayAction: no cached state for ${entityId}`);
             return;
         }
+        await this.startAnimationForEntity(contextId, action, entity);
+    }
 
-        const matchingContexts = Array.from(this.getAllContexts()).filter(
-            ([, context]) => context.settings.entityId === entityId,
-        );
+    private async startAnimationForEntity(
+        contextId: string,
+        action: KeyAction<ActionSettings>,
+        entity: HomeAssistantEntity,
+    ): Promise<void> {
+        const frames = getWeatherFrames(entity.state, formatTemperatureLabel(entity));
 
-        const svg = getWeatherAnimationSvg(entity.state, formatTemperatureLabel(entity));
-        await Promise.all(
-            matchingContexts.map(([, context]) => Promise.all([
-                context.action.setImage(svg),
-                context.action.setTitle(""),
-            ])),
-        );
+        // Show the first frame immediately
+        await Promise.all([action.setImage(frames[0]), action.setTitle("")]);
+
+        if (frames.length <= 1) {
+            return;
+        }
+
+        let frameIndex = 1;
+        const timer = setInterval(() => {
+            const state = this.animations.get(contextId);
+            if (!state) return;
+            state.frameIndex = frameIndex;
+            void action.setImage(frames[frameIndex]);
+            frameIndex = (frameIndex + 1) % frames.length;
+        }, WEATHER_FRAME_INTERVAL_MS);
+
+        this.animations.set(contextId, { frames, frameIndex: 0, timer });
+    }
+
+    private stopAnimation(contextId: string): void {
+        const state = this.animations.get(contextId);
+        if (state) {
+            clearInterval(state.timer);
+            this.animations.delete(contextId);
+        }
     }
 }
 

--- a/src/plugin/actions/weatherUtils.ts
+++ b/src/plugin/actions/weatherUtils.ts
@@ -12,3 +12,12 @@ export function formatWeatherTitle(entity: HomeAssistantEntity): string {
     const unit = temperatureUnit ?? "°";
     return `${condition}\n${temperature}${unit}`;
 }
+
+export function formatTemperatureLabel(entity: HomeAssistantEntity): string | undefined {
+    const temperature = entity.attributes["temperature"];
+    if (temperature === undefined || temperature === null) {
+        return undefined;
+    }
+    const unit = (entity.attributes["temperature_unit"] as string | undefined) ?? "°";
+    return `${temperature}${unit}`;
+}

--- a/src/plugin/utils/weatherAnimations.ts
+++ b/src/plugin/utils/weatherAnimations.ts
@@ -1,27 +1,35 @@
 /**
- * Returns an animated SVG string for a given weather condition.
- * @param condition - The weather entity state (e.g. "sunny", "rainy", "clear-night")
- * @param temperature - Formatted temperature string (e.g. "22°C"), optional overlay
+ * Returns an array of static SVG frames that can be cycled to produce weather animations.
+ * Stream Deck rasterizes SVG to a bitmap so SMIL animations don't work; use setInterval + frame cycling instead.
  */
-export function getWeatherAnimationSvg(condition: string, temperature?: string): string {
+export function getWeatherFrames(condition: string, temperature?: string): string[] {
     switch (condition) {
-        case "sunny": return sunny(temperature);
-        case "clear-night": return clearNight(temperature);
-        case "cloudy": return cloudy(temperature);
-        case "fog": return fog(temperature);
-        case "hail": return hail(temperature);
-        case "lightning": return lightning(temperature);
-        case "lightning-rainy": return lightningRainy(temperature);
-        case "partlycloudy": return partlyCloudy(temperature);
-        case "pouring": return pouring(temperature);
-        case "rainy": return rainy(temperature);
-        case "snowy": return snowy(temperature);
-        case "snowy-rainy": return snowyRainy(temperature);
-        case "windy": return windy(temperature);
-        case "windy-variant": return windyVariant(temperature);
-        case "exceptional": return exceptional(temperature);
-        default: return defaultWeather(condition, temperature);
+        case "sunny": return sunnyFrames(temperature);
+        case "clear-night": return clearNightFrames(temperature);
+        case "cloudy": return cloudyFrames(temperature);
+        case "fog": return fogFrames(temperature);
+        case "hail": return hailFrames(temperature);
+        case "lightning": return lightningFrames(temperature);
+        case "lightning-rainy": return lightningRainyFrames(temperature);
+        case "partlycloudy": return partlyCloudyFrames(temperature);
+        case "pouring": return pouringFrames(temperature);
+        case "rainy": return rainyFrames(temperature);
+        case "snowy": return snowyFrames(temperature);
+        case "snowy-rainy": return snowyRainyFrames(temperature);
+        case "windy": return windyFrames(temperature);
+        case "windy-variant": return windyVariantFrames(temperature);
+        case "exceptional": return exceptionalFrames(temperature);
+        default: return [defaultWeather(condition, temperature)];
     }
+}
+
+/** Interval in ms between frames */
+export const WEATHER_FRAME_INTERVAL_MS = 250;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function svg(body: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">${body}</svg>`;
 }
 
 function tempLabel(temperature?: string): string {
@@ -29,441 +37,347 @@ function tempLabel(temperature?: string): string {
     return `<text x="72" y="136" text-anchor="middle" fill="white" font-size="20" font-family="Arial,sans-serif" font-weight="bold" stroke="#000000" stroke-width="3" paint-order="stroke">${temperature}</text>`;
 }
 
-function cloud(cx: number, cy: number, fill: string): string {
-    return `<ellipse cx="${cx - 18}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>
-  <ellipse cx="${cx}" cy="${cy}" rx="20" ry="16" fill="${fill}"/>
-  <ellipse cx="${cx + 20}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>
-  <rect x="${cx - 33}" y="${cy + 8}" width="69" height="14" fill="${fill}"/>`;
+function cloudShape(cx: number, cy: number, fill: string): string {
+    return `<ellipse cx="${cx - 18}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>` +
+        `<ellipse cx="${cx}" cy="${cy}" rx="20" ry="16" fill="${fill}"/>` +
+        `<ellipse cx="${cx + 20}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>` +
+        `<rect x="${cx - 33}" y="${cy + 8}" width="69" height="14" fill="${fill}"/>`;
 }
 
-// Sunny: rotating rays + pulsing sun circle on blue sky
-function sunny(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="sky" cx="50%" cy="30%">
-      <stop offset="0%" stop-color="#60b8f0"/>
-      <stop offset="100%" stop-color="#1a7ac4"/>
-    </radialGradient>
-    <radialGradient id="sun" cx="40%" cy="40%">
-      <stop offset="0%" stop-color="#fff8a0"/>
-      <stop offset="100%" stop-color="#ffaa00"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#sky)"/>
-  <g transform="translate(72,56)">
-    <g>
-      <animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="8s" repeatCount="indefinite"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(45)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(90)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(135)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(180)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(225)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(270)"/>
-      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(315)"/>
-    </g>
-    <circle r="24" fill="url(#sun)">
-      <animate attributeName="r" values="24;27;24" dur="2s" repeatCount="indefinite"/>
-    </circle>
-  </g>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Sunny: rotating sun (8 frames × 45°) ───────────────────────────────────
+
+function sunBody(rotateDeg: number, temperature?: string): string {
+    const rays = [0, 45, 90, 135, 180, 225, 270, 315].map(deg => {
+        const r = (deg + rotateDeg) * (Math.PI / 180);
+        const x1 = Math.round(72 + Math.cos(r) * 28);
+        const y1 = Math.round(56 + Math.sin(r) * 28);
+        const x2 = Math.round(72 + Math.cos(r) * 42);
+        const y2 = Math.round(56 + Math.sin(r) * 42);
+        return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#ffcc00" stroke-width="4" stroke-linecap="round"/>`;
+    }).join("");
+    return svg(
+        `<defs><radialGradient id="sk"><stop offset="0%" stop-color="#60b8f0"/><stop offset="100%" stop-color="#1a7ac4"/></radialGradient>` +
+        `<radialGradient id="sn" cx="40%" cy="40%"><stop offset="0%" stop-color="#fff8a0"/><stop offset="100%" stop-color="#ffaa00"/></radialGradient></defs>` +
+        `<rect width="144" height="144" fill="url(#sk)"/>` +
+        rays +
+        `<circle cx="72" cy="56" r="24" fill="url(#sn)"/>` +
+        tempLabel(temperature)
+    );
 }
 
-// Clear night: dark sky, crescent moon, twinkling stars
-function clearNight(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="nightsky" cx="50%" cy="30%">
-      <stop offset="0%" stop-color="#1a2f5c"/>
-      <stop offset="100%" stop-color="#050d1a"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#nightsky)"/>
-  <circle cx="22" cy="18" r="2" fill="white"><animate attributeName="opacity" values="1;0.2;1" dur="2.1s" repeatCount="indefinite"/></circle>
-  <circle cx="48" cy="28" r="1.5" fill="white"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
-  <circle cx="102" cy="14" r="2" fill="white"><animate attributeName="opacity" values="1;0.3;1" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="122" cy="34" r="1.5" fill="white"><animate attributeName="opacity" values="0.7;1;0.7" dur="1.5s" repeatCount="indefinite"/></circle>
-  <circle cx="32" cy="50" r="1" fill="white"><animate attributeName="opacity" values="1;0.4;1" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="118" cy="52" r="2" fill="white"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/></circle>
-  <circle cx="62" cy="10" r="1.5" fill="white"><animate attributeName="opacity" values="1;0.6;1" dur="1.9s" repeatCount="indefinite"/></circle>
-  <circle cx="85" cy="24" r="1" fill="white"><animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/></circle>
-  <!-- Crescent moon: large lit circle minus offset dark circle -->
-  <circle cx="72" cy="58" r="26" fill="#fffacc"/>
-  <circle cx="84" cy="50" r="22" fill="#1a2f5c"/>
-  <!-- Soft glow ring -->
-  <circle cx="66" cy="62" r="22" fill="none" stroke="#fffacc" stroke-width="2" opacity="0.25">
-    <animate attributeName="r" values="22;27;22" dur="3s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.25;0.08;0.25" dur="3s" repeatCount="indefinite"/>
-  </circle>
-  ${tempLabel(temperature)}
-</svg>`;
+function sunnyFrames(temperature?: string): string[] {
+    return [0, 45, 90, 135, 180, 225, 270, 315].map(deg => sunBody(deg, temperature));
 }
 
-// Cloudy: overcast sky with two drifting cloud layers
-function cloudy(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#6a8aaa"/>
-  <!-- Background cloud, drifts right -->
-  <g opacity="0.55">
-    <animateTransform attributeName="transform" type="translate" values="0,0;10,0;0,0" dur="6s" repeatCount="indefinite"/>
-    ${cloud(50, 68, "#9ab4c8")}
-  </g>
-  <!-- Foreground cloud, drifts left -->
-  <g>
-    <animateTransform attributeName="transform" type="translate" values="0,0;-8,0;0,0" dur="8s" repeatCount="indefinite"/>
-    ${cloud(76, 44, "#dde8f0")}
-  </g>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Clear night: twinkling stars (4 frames) ────────────────────────────────
+
+function clearNightFrames(temperature?: string): string[] {
+    const stars = [
+        { x: 22, y: 18 }, { x: 48, y: 28 }, { x: 102, y: 14 }, { x: 122, y: 34 },
+        { x: 32, y: 50 }, { x: 118, y: 52 }, { x: 62, y: 10 }, { x: 85, y: 24 },
+    ];
+    const bg =
+        `<defs><radialGradient id="ns"><stop offset="0%" stop-color="#1a2f5c"/><stop offset="100%" stop-color="#050d1a"/></radialGradient></defs>` +
+        `<rect width="144" height="144" fill="url(#ns)"/>`;
+    const moon =
+        `<circle cx="72" cy="58" r="26" fill="#fffacc"/><circle cx="84" cy="50" r="22" fill="#1a2f5c"/>`;
+
+    return [0, 1, 2, 3].map(frame =>
+        svg(bg + stars.map((s, i) => {
+            const op = ((i + frame) % 4 === 0) ? "0.2" : "1";
+            return `<circle cx="${s.x}" cy="${s.y}" r="2" fill="white" opacity="${op}"/>`;
+        }).join("") + moon + tempLabel(temperature))
+    );
 }
 
-// Fog: light gray with animated horizontal fog bands scrolling
-function fog(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#b0bcc4"/>
-  <rect x="0" y="22" width="200" height="11" rx="5" fill="white" opacity="0.6">
-    <animateTransform attributeName="transform" type="translate" values="0,0;30,0;0,0" dur="4s" repeatCount="indefinite"/>
-  </rect>
-  <rect x="-30" y="40" width="200" height="9" rx="4" fill="white" opacity="0.5">
-    <animateTransform attributeName="transform" type="translate" values="0,0;-26,0;0,0" dur="5s" repeatCount="indefinite"/>
-  </rect>
-  <rect x="0" y="57" width="200" height="11" rx="5" fill="white" opacity="0.65">
-    <animateTransform attributeName="transform" type="translate" values="0,0;22,0;0,0" dur="3.6s" repeatCount="indefinite"/>
-  </rect>
-  <rect x="-20" y="75" width="200" height="9" rx="4" fill="white" opacity="0.45">
-    <animateTransform attributeName="transform" type="translate" values="0,0;-32,0;0,0" dur="6s" repeatCount="indefinite"/>
-  </rect>
-  <rect x="0" y="92" width="200" height="11" rx="5" fill="white" opacity="0.55">
-    <animateTransform attributeName="transform" type="translate" values="0,0;18,0;0,0" dur="4.5s" repeatCount="indefinite"/>
-  </rect>
-  <rect x="-10" y="108" width="200" height="9" rx="4" fill="white" opacity="0.4">
-    <animateTransform attributeName="transform" type="translate" values="0,0;-20,0;0,0" dur="5.5s" repeatCount="indefinite"/>
-  </rect>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Cloudy: drifting clouds (4 frames) ──────────────────────────────────────
+
+function cloudyFrames(temperature?: string): string[] {
+    const offsets = [0, 4, 8, 4];
+    return offsets.map(ox =>
+        svg(
+            `<rect width="144" height="144" fill="#6a8aaa"/>` +
+            `<g transform="translate(${ox - 4},0)" opacity="0.55">${cloudShape(50, 68, "#9ab4c8")}</g>` +
+            `<g transform="translate(${-ox},0)">${cloudShape(76, 44, "#dde8f0")}</g>` +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Hail: dark storm cloud + animated falling hailstones
-function hail(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#4a6480"/>
-  ${cloud(72, 34, "#708090")}
-  <!-- Hailstones: staggered falling ovals -->
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.4s" begin="0s" repeatCount="indefinite"/>
-    <ellipse cx="40" cy="0" rx="5" ry="4" fill="#d4eeff">
-      <animate attributeName="cy" from="62" to="134" dur="1.4s" begin="0s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.2s" begin="-0.4s" repeatCount="indefinite"/>
-    <ellipse cx="60" cy="0" rx="4" ry="3" fill="#d4eeff">
-      <animate attributeName="cy" from="60" to="134" dur="1.2s" begin="-0.4s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.6s" begin="-0.8s" repeatCount="indefinite"/>
-    <ellipse cx="80" cy="0" rx="5" ry="4" fill="#d4eeff">
-      <animate attributeName="cy" from="62" to="134" dur="1.6s" begin="-0.8s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.3s" begin="-0.2s" repeatCount="indefinite"/>
-    <ellipse cx="100" cy="0" rx="4" ry="3" fill="#d4eeff">
-      <animate attributeName="cy" from="60" to="134" dur="1.3s" begin="-0.2s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.5s" begin="-1.0s" repeatCount="indefinite"/>
-    <ellipse cx="118" cy="0" rx="5" ry="4" fill="#d4eeff">
-      <animate attributeName="cy" from="62" to="134" dur="1.5s" begin="-1.0s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.4s" begin="-0.6s" repeatCount="indefinite"/>
-    <ellipse cx="50" cy="0" rx="4" ry="3" fill="#d4eeff">
-      <animate attributeName="cy" from="58" to="134" dur="1.4s" begin="-0.6s" repeatCount="indefinite"/>
-    </ellipse>
-  </g>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Fog: scrolling bands (4 frames) ─────────────────────────────────────────
+
+function fogFrames(temperature?: string): string[] {
+    const bandShifts = [0, 8, 16, 8];
+    return bandShifts.map(shift =>
+        svg(
+            `<rect width="144" height="144" fill="#b0bcc4"/>` +
+            [22, 40, 57, 75, 92, 108].map((y, i) => {
+                const dx = i % 2 === 0 ? shift : -shift;
+                const w = i % 2 === 0 ? 11 : 9;
+                const op = ["0.6", "0.5", "0.65", "0.45", "0.55", "0.4"][i];
+                return `<rect x="${dx}" y="${y}" width="200" height="${w}" rx="5" fill="white" opacity="${op}"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Lightning: dark stormy sky + cloud + flashing bolt
-function lightning(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="stormy" cx="50%" cy="30%">
-      <stop offset="0%" stop-color="#2a2a4e"/>
-      <stop offset="100%" stop-color="#0a0a1a"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#stormy)"/>
-  ${cloud(72, 32, "#4a4a6a")}
-  <!-- Lightning bolt -->
-  <polygon points="76,54 62,82 72,82 62,110 86,76 74,76 84,54" fill="#ffee00">
-    <animate attributeName="opacity" values="0;0;1;1;0.2;1;0;0;0;0" dur="3s" repeatCount="indefinite"/>
-  </polygon>
-  <!-- Flash effect on background -->
-  <rect width="144" height="144" fill="#fffde0" opacity="0">
-    <animate attributeName="opacity" values="0;0;0.15;0;0;0;0;0;0;0" dur="3s" repeatCount="indefinite"/>
-  </rect>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Hail: falling stones (4 frames) ─────────────────────────────────────────
+
+function hailFrames(temperature?: string): string[] {
+    const stoneXs = [40, 60, 80, 100, 118, 50];
+    const totalFall = 72; // from cloud bottom to bottom of key
+    return [0, 1, 2, 3].map(frame =>
+        svg(
+            `<rect width="144" height="144" fill="#4a6480"/>` +
+            cloudShape(72, 34, "#708090") +
+            stoneXs.map((x, i) => {
+                const phase = (frame + i * 2) % 4;
+                const y = 62 + Math.round((phase / 4) * totalFall);
+                return `<ellipse cx="${x}" cy="${y}" rx="5" ry="4" fill="#d4eeff"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Lightning-rainy: dark cloud + flashing bolt + rain streaks
-function lightningRainy(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#3a4a5e"/>
-  ${cloud(72, 28, "#505a6a")}
-  <!-- Rain streaks (fast) -->
-  <g opacity="0.8">
-    <line x1="36" y1="0" x2="32" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
-      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="0s" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="0s" repeatCount="indefinite"/>
-    </line>
-    <line x1="56" y1="0" x2="52" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
-      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.2s" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.2s" repeatCount="indefinite"/>
-    </line>
-    <line x1="96" y1="0" x2="92" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
-      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.4s" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.4s" repeatCount="indefinite"/>
-    </line>
-    <line x1="116" y1="0" x2="112" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
-      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.1s" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.1s" repeatCount="indefinite"/>
-    </line>
-  </g>
-  <!-- Lightning bolt -->
-  <polygon points="76,50 63,76 72,76 62,100 84,70 73,70 82,50" fill="#ffee00">
-    <animate attributeName="opacity" values="0;0;1;1;0.3;1;0;0;0;0" dur="2.5s" repeatCount="indefinite"/>
-  </polygon>
-  <rect width="144" height="144" fill="#fffde0" opacity="0">
-    <animate attributeName="opacity" values="0;0;0.12;0;0;0;0;0;0;0" dur="2.5s" repeatCount="indefinite"/>
-  </rect>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Lightning: bolt flash (6 frames) ────────────────────────────────────────
+
+function lightningFrames(temperature?: string): string[] {
+    const bolt = `<polygon points="76,54 62,82 72,82 62,110 86,76 74,76 84,54" fill="#ffee00"/>`;
+    const boltHidden = `<polygon points="76,54 62,82 72,82 62,110 86,76 74,76 84,54" fill="#ffee00" opacity="0"/>`;
+    const bgNormal =
+        `<defs><radialGradient id="st"><stop offset="0%" stop-color="#2a2a4e"/><stop offset="100%" stop-color="#0a0a1a"/></radialGradient></defs>` +
+        `<rect width="144" height="144" fill="url(#st)"/>` + cloudShape(72, 32, "#4a4a6a");
+    const bgFlash =
+        `<defs><radialGradient id="st"><stop offset="0%" stop-color="#3a3a6e"/><stop offset="100%" stop-color="#1a1a3a"/></radialGradient></defs>` +
+        `<rect width="144" height="144" fill="url(#st)"/>` + cloudShape(72, 32, "#5a5a8a");
+
+    // frames: 0=off, 1=off, 2=flash, 3=bright, 4=off, 5=off
+    return [
+        svg(bgNormal + boltHidden + tempLabel(temperature)),
+        svg(bgNormal + boltHidden + tempLabel(temperature)),
+        svg(bgFlash + bolt + tempLabel(temperature)),
+        svg(bgFlash + bolt + tempLabel(temperature)),
+        svg(bgNormal + boltHidden + tempLabel(temperature)),
+        svg(bgNormal + boltHidden + tempLabel(temperature)),
+    ];
 }
 
-// Partly cloudy: blue sky, sun at back, cloud drifting in front
-function partlyCloudy(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="partsky" cx="50%" cy="30%">
-      <stop offset="0%" stop-color="#60b8f0"/>
-      <stop offset="100%" stop-color="#2a8ad4"/>
-    </radialGradient>
-    <radialGradient id="partsun" cx="40%" cy="40%">
-      <stop offset="0%" stop-color="#fff8a0"/>
-      <stop offset="100%" stop-color="#ffaa00"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#partsky)"/>
-  <!-- Sun (behind cloud) -->
-  <circle cx="48" cy="48" r="22" fill="url(#partsun)">
-    <animate attributeName="r" values="22;25;22" dur="3s" repeatCount="indefinite"/>
-  </circle>
-  <!-- Short sun rays -->
-  <g transform="translate(48,48)">
-    <animateTransform attributeName="transform" type="rotate" from="0 48 48" to="360 48 48" dur="10s" repeatCount="indefinite" additive="replace"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(60 0 0)"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(120 0 0)"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(180 0 0)"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(240 0 0)"/>
-    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(300 0 0)"/>
-  </g>
-  <!-- Cloud in front -->
-  <g>
-    <animateTransform attributeName="transform" type="translate" values="0,0;6,0;0,0" dur="7s" repeatCount="indefinite"/>
-    ${cloud(82, 52, "#e8f2fa")}
-  </g>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Lightning+Rain: bolt + falling rain (6 frames) ──────────────────────────
+
+function rainLines(frame: number, color: string, count: number): string {
+    const totalFall = 72;
+    const xs = [36, 56, 76, 96, 116, 46, 66, 86, 106].slice(0, count);
+    return xs.map((x, i) => {
+        const phase = (frame + i) % 4;
+        const y = 54 + Math.round((phase / 4) * totalFall);
+        return `<line x1="${x}" y1="${y}" x2="${x - 3}" y2="${y + 14}" stroke="${color}" stroke-width="2" stroke-linecap="round"/>`;
+    }).join("");
 }
 
-// Pouring: dark cloud + many fast heavy rain streaks
-function pouring(temperature?: string): string {
-    const rainLine = (x: number, delay: string) =>
-        `<line x1="${x}" y1="0" x2="${x - 4}" y2="18" stroke="#80aadd" stroke-width="2.5" stroke-linecap="round">
-      <animate attributeName="y1" from="54" to="120" dur="0.5s" begin="${delay}" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="72" to="138" dur="0.5s" begin="${delay}" repeatCount="indefinite"/>
-    </line>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#3a4e62"/>
-  ${cloud(72, 30, "#586070")}
-  ${rainLine(30, "0s")}
-  ${rainLine(46, "-0.1s")}
-  ${rainLine(62, "-0.2s")}
-  ${rainLine(78, "-0.3s")}
-  ${rainLine(94, "-0.4s")}
-  ${rainLine(110, "-0.15s")}
-  ${rainLine(38, "-0.35s")}
-  ${rainLine(54, "-0.45s")}
-  ${rainLine(70, "-0.05s")}
-  ${rainLine(86, "-0.25s")}
-  ${rainLine(102, "-0.4s")}
-  ${rainLine(118, "-0.1s")}
-  ${tempLabel(temperature)}
-</svg>`;
+function lightningRainyFrames(temperature?: string): string[] {
+    const bolt = `<polygon points="76,50 63,76 72,76 62,100 84,70 73,70 82,50" fill="#ffee00"/>`;
+    const boltHidden = `<polygon points="76,50 63,76 72,76 62,100 84,70 73,70 82,50" fill="#ffee00" opacity="0"/>`;
+    const bgNormal = `<rect width="144" height="144" fill="#3a4a5e"/>` + cloudShape(72, 28, "#505a6a");
+    const bgFlash = `<rect width="144" height="144" fill="#4a5a6e"/>` + cloudShape(72, 28, "#606a7a");
+
+    return [0, 1, 2, 3, 4, 5].map(frame => {
+        const isFlash = frame === 2 || frame === 3;
+        return svg(
+            (isFlash ? bgFlash : bgNormal) +
+            rainLines(frame, "#80aadd", 4) +
+            (isFlash ? bolt : boltHidden) +
+            tempLabel(temperature)
+        );
+    });
 }
 
-// Rainy: overcast sky, cloud, moderate falling rain
-function rainy(temperature?: string): string {
-    const rainLine = (x: number, delay: string) =>
-        `<line x1="${x}" y1="0" x2="${x - 3}" y2="14" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
-      <animate attributeName="y1" from="56" to="124" dur="0.9s" begin="${delay}" repeatCount="indefinite"/>
-      <animate attributeName="y2" from="70" to="138" dur="0.9s" begin="${delay}" repeatCount="indefinite"/>
-    </line>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#5a7090"/>
-  ${cloud(72, 34, "#7080a0")}
-  ${rainLine(36, "0s")}
-  ${rainLine(56, "-0.3s")}
-  ${rainLine(76, "-0.6s")}
-  ${rainLine(96, "-0.15s")}
-  ${rainLine(116, "-0.45s")}
-  ${rainLine(46, "-0.75s")}
-  ${rainLine(66, "-0.5s")}
-  ${rainLine(86, "-0.2s")}
-  ${rainLine(106, "-0.8s")}
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Partly cloudy: cloud slides across rotating sun (8 frames) ──────────────
+
+function partlyCloudyFrames(temperature?: string): string[] {
+    const cloudOffsets = [0, 2, 4, 6, 8, 6, 4, 2];
+    return cloudOffsets.map((ox, i) => {
+        const deg = i * 45;
+        const r = deg * (Math.PI / 180);
+        const rays = [0, 60, 120, 180, 240, 300].map(d => {
+            const ra = (d + deg) * (Math.PI / 180);
+            const x1 = Math.round(48 + Math.cos(ra) * 28);
+            const y1 = Math.round(48 + Math.sin(ra) * 28);
+            const x2 = Math.round(48 + Math.cos(ra) * 36);
+            const y2 = Math.round(48 + Math.sin(ra) * 36);
+            return `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="#ffcc00" stroke-width="3" stroke-linecap="round"/>`;
+        }).join("");
+        return svg(
+            `<defs><radialGradient id="psk"><stop offset="0%" stop-color="#60b8f0"/><stop offset="100%" stop-color="#2a8ad4"/></radialGradient>` +
+            `<radialGradient id="psn" cx="40%" cy="40%"><stop offset="0%" stop-color="#fff8a0"/><stop offset="100%" stop-color="#ffaa00"/></radialGradient></defs>` +
+            `<rect width="144" height="144" fill="url(#psk)"/>` +
+            rays +
+            `<circle cx="48" cy="48" r="22" fill="url(#psn)"/>` +
+            `<g transform="translate(${ox},0)">${cloudShape(82, 52, "#e8f2fa")}</g>` +
+            tempLabel(temperature)
+        );
+    });
 }
 
-// Snowy: light blue sky, cloud, snowflakes falling and spinning
-function snowy(temperature?: string): string {
-    const flake = (x: number, delay: string, size: number) =>
-        `<text x="${x}" y="0" font-size="${size}" fill="white" text-anchor="middle" opacity="0.9">❄
-      <animate attributeName="y" from="56" to="138" dur="2s" begin="${delay}" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2s" begin="${delay}" repeatCount="indefinite"/>
-    </text>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#7090b4"/>
-  ${cloud(72, 32, "#90a8be")}
-  ${flake(32, "0s", 14)}
-  ${flake(54, "-0.5s", 12)}
-  ${flake(74, "-1.0s", 14)}
-  ${flake(94, "-1.5s", 12)}
-  ${flake(114, "-0.7s", 14)}
-  ${flake(44, "-1.2s", 11)}
-  ${flake(64, "-0.3s", 13)}
-  ${flake(84, "-1.7s", 11)}
-  ${flake(104, "-0.9s", 12)}
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Pouring: fast heavy rain (4 frames) ─────────────────────────────────────
+
+function pouringFrames(temperature?: string): string[] {
+    const xs = [30, 46, 62, 78, 94, 110, 38, 54, 70, 86, 102, 118];
+    const totalFall = 64;
+    return [0, 1, 2, 3].map(frame =>
+        svg(
+            `<rect width="144" height="144" fill="#3a4e62"/>` +
+            cloudShape(72, 30, "#586070") +
+            xs.map((x, i) => {
+                const phase = (frame + i) % 4;
+                const y = 56 + Math.round((phase / 4) * totalFall);
+                return `<line x1="${x}" y1="${y}" x2="${x - 4}" y2="${y + 18}" stroke="#80aadd" stroke-width="2.5" stroke-linecap="round"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Snowy-rainy: mix of rain streaks and snowflakes
-function snowyRainy(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#607888"/>
-  ${cloud(72, 30, "#7888a0")}
-  <!-- Rain streaks -->
-  <line x1="36" y1="0" x2="33" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
-    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="0s" repeatCount="indefinite"/>
-    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="0s" repeatCount="indefinite"/>
-  </line>
-  <line x1="72" y1="0" x2="69" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
-    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="-0.3s" repeatCount="indefinite"/>
-    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="-0.3s" repeatCount="indefinite"/>
-  </line>
-  <line x1="108" y1="0" x2="105" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
-    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="-0.6s" repeatCount="indefinite"/>
-    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="-0.6s" repeatCount="indefinite"/>
-  </line>
-  <!-- Snowflakes -->
-  <text x="54" y="0" font-size="13" fill="white" text-anchor="middle" opacity="0.9">❄
-    <animate attributeName="y" from="58" to="134" dur="2.2s" begin="-0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-0.4s" repeatCount="indefinite"/>
-  </text>
-  <text x="90" y="0" font-size="12" fill="white" text-anchor="middle" opacity="0.9">❄
-    <animate attributeName="y" from="60" to="134" dur="2.2s" begin="-1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-1.2s" repeatCount="indefinite"/>
-  </text>
-  <text x="36" y="0" font-size="11" fill="white" text-anchor="middle" opacity="0.9">❄
-    <animate attributeName="y" from="58" to="134" dur="2.2s" begin="-1.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-1.8s" repeatCount="indefinite"/>
-  </text>
-  <text x="112" y="0" font-size="13" fill="white" text-anchor="middle" opacity="0.9">❄
-    <animate attributeName="y" from="60" to="134" dur="2.2s" begin="-0.9s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-0.9s" repeatCount="indefinite"/>
-  </text>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Rainy: moderate rain (4 frames) ─────────────────────────────────────────
+
+function rainyFrames(temperature?: string): string[] {
+    const xs = [36, 56, 76, 96, 116, 46, 66, 86, 106];
+    const totalFall = 62;
+    return [0, 1, 2, 3].map(frame =>
+        svg(
+            `<rect width="144" height="144" fill="#5a7090"/>` +
+            cloudShape(72, 34, "#7080a0") +
+            xs.map((x, i) => {
+                const phase = (frame + i) % 4;
+                const y = 56 + Math.round((phase / 4) * totalFall);
+                return `<line x1="${x}" y1="${y}" x2="${x - 3}" y2="${y + 14}" stroke="#7090c0" stroke-width="2" stroke-linecap="round"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Windy: blue sky with animated arcing wind streaks scrolling left
-function windy(temperature?: string): string {
-    const windArc = (y: number, width: number, dur: string, begin: string) =>
-        `<path d="M160,${y} Q110,${y - 8} 60,${y} Q10,${y + 8} -40,${y}" fill="none" stroke="white" stroke-width="${width}" stroke-linecap="round" opacity="0.7">
-      <animateTransform attributeName="transform" type="translate" values="0,0;-200,0" dur="${dur}" begin="${begin}" repeatCount="indefinite"/>
-    </path>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="windsky" cx="50%" cy="30%">
-      <stop offset="0%" stop-color="#70c0f0"/>
-      <stop offset="100%" stop-color="#2a90d4"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#windsky)"/>
-  ${windArc(28, 3.5, "1.8s", "0s")}
-  ${windArc(44, 2.5, "2.2s", "-0.4s")}
-  ${windArc(60, 3.5, "1.9s", "-0.8s")}
-  ${windArc(76, 2.5, "2.4s", "-1.2s")}
-  ${windArc(92, 3, "1.7s", "-0.6s")}
-  ${windArc(108, 2.5, "2.1s", "-1.5s")}
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Snowy: falling snowflakes (4 frames) ────────────────────────────────────
+
+function snowflake(x: number, y: number, size: number): string {
+    const s = size / 2;
+    return `<line x1="${x - s}" y1="${y}" x2="${x + s}" y2="${y}" stroke="white" stroke-width="2" stroke-linecap="round"/>` +
+        `<line x1="${x}" y1="${y - s}" x2="${x}" y2="${y + s}" stroke="white" stroke-width="2" stroke-linecap="round"/>` +
+        `<line x1="${x - s * 0.7}" y1="${y - s * 0.7}" x2="${x + s * 0.7}" y2="${y + s * 0.7}" stroke="white" stroke-width="1.5" stroke-linecap="round"/>` +
+        `<line x1="${x + s * 0.7}" y1="${y - s * 0.7}" x2="${x - s * 0.7}" y2="${y + s * 0.7}" stroke="white" stroke-width="1.5" stroke-linecap="round"/>`;
 }
 
-// Windy-variant: cloud + wind streaks
-function windyVariant(temperature?: string): string {
-    const windLine = (y: number, x1: number, x2: number, delay: string) =>
-        `<line x1="${x1}" y1="${y}" x2="${x2}" y2="${y}" stroke="white" stroke-width="3" stroke-linecap="round" opacity="0.7">
-      <animateTransform attributeName="transform" type="translate" values="0,0;-20,0;0,0" dur="1.8s" begin="${delay}" repeatCount="indefinite"/>
-    </line>`;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#6090b0"/>
-  ${cloud(72, 34, "#88a8c0")}
-  ${windLine(68, 10, 70, "0s")}
-  ${windLine(80, 20, 90, "-0.3s")}
-  ${windLine(92, 8, 80, "-0.6s")}
-  ${windLine(104, 24, 100, "-0.9s")}
-  ${windLine(116, 12, 72, "-0.4s")}
-  ${tempLabel(temperature)}
-</svg>`;
+function snowyFrames(temperature?: string): string[] {
+    const flakes = [
+        { x: 32, size: 10 }, { x: 54, size: 8 }, { x: 74, size: 10 },
+        { x: 94, size: 8 }, { x: 114, size: 10 }, { x: 44, size: 9 },
+        { x: 64, size: 8 }, { x: 84, size: 9 }, { x: 104, size: 8 },
+    ];
+    const totalFall = 72;
+    return [0, 1, 2, 3].map(frame =>
+        svg(
+            `<rect width="144" height="144" fill="#7090b4"/>` +
+            cloudShape(72, 32, "#90a8be") +
+            flakes.map((f, i) => {
+                const phase = (frame + i * 2) % 4;
+                const y = 58 + Math.round((phase / 4) * totalFall);
+                return snowflake(f.x, y, f.size);
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Exceptional: red/orange background, pulsing warning triangle
-function exceptional(temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <defs>
-    <radialGradient id="exceptbg" cx="50%" cy="50%">
-      <stop offset="0%" stop-color="#cc4400"/>
-      <stop offset="100%" stop-color="#660000"/>
-    </radialGradient>
-  </defs>
-  <rect width="144" height="144" fill="url(#exceptbg)"/>
-  <!-- Pulsing outer ring -->
-  <circle cx="72" cy="60" r="46" fill="none" stroke="#ff8800" stroke-width="3" opacity="0.5">
-    <animate attributeName="r" values="46;54;46" dur="1.5s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.5;0.1;0.5" dur="1.5s" repeatCount="indefinite"/>
-  </circle>
-  <!-- Warning triangle -->
-  <polygon points="72,18 118,96 26,96" fill="#ffcc00">
-    <animate attributeName="opacity" values="1;0.6;1" dur="1.5s" repeatCount="indefinite"/>
-  </polygon>
-  <polygon points="72,30 110,90 34,90" fill="#ff8800"/>
-  <!-- Exclamation mark -->
-  <rect x="68" y="44" width="8" height="28" rx="3" fill="#1a0000"/>
-  <circle cx="72" cy="82" r="5" fill="#1a0000"/>
-  ${tempLabel(temperature)}
-</svg>`;
+// ─── Snowy-rainy: mixed (4 frames) ───────────────────────────────────────────
+
+function snowyRainyFrames(temperature?: string): string[] {
+    const rainXs = [36, 72, 108];
+    const flakeXs = [54, 90, 36, 112];
+    const totalFall = 72;
+    return [0, 1, 2, 3].map(frame =>
+        svg(
+            `<rect width="144" height="144" fill="#607888"/>` +
+            cloudShape(72, 30, "#7888a0") +
+            rainXs.map((x, i) => {
+                const phase = (frame + i * 2) % 4;
+                const y = 54 + Math.round((phase / 4) * totalFall);
+                return `<line x1="${x}" y1="${y}" x2="${x - 3}" y2="${y + 12}" stroke="#7090c0" stroke-width="2" stroke-linecap="round"/>`;
+            }).join("") +
+            flakeXs.map((x, i) => {
+                const phase = (frame + i * 3) % 4;
+                const y = 58 + Math.round((phase / 4) * totalFall);
+                return snowflake(x, y, 9);
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
 }
 
-// Default fallback: neutral background with condition text
+// ─── Windy: scrolling wind arcs (4 frames) ───────────────────────────────────
+
+function windyFrames(temperature?: string): string[] {
+    const arcYs = [28, 44, 60, 76, 92, 108];
+    const shifts = [0, 12, 24, 12];
+    return shifts.map(shift =>
+        svg(
+            `<defs><radialGradient id="wsk"><stop offset="0%" stop-color="#70c0f0"/><stop offset="100%" stop-color="#2a90d4"/></radialGradient></defs>` +
+            `<rect width="144" height="144" fill="url(#wsk)"/>` +
+            arcYs.map((y, i) => {
+                const dx = i % 2 === 0 ? -shift : shift;
+                const w = i % 2 === 0 ? 3.5 : 2.5;
+                return `<path d="M${16 + dx},${y} Q${60 + dx},${y - 8} ${104 + dx},${y} Q${128 + dx},${y + 6} ${144 + dx},${y}" ` +
+                    `fill="none" stroke="white" stroke-width="${w}" stroke-linecap="round" opacity="0.75"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
+}
+
+// ─── Windy-variant: cloud + scrolling wind lines (4 frames) ──────────────────
+
+function windyVariantFrames(temperature?: string): string[] {
+    const lineYs = [68, 80, 92, 104, 116];
+    const shifts = [0, 6, 12, 6];
+    return shifts.map(shift =>
+        svg(
+            `<rect width="144" height="144" fill="#6090b0"/>` +
+            cloudShape(72, 34, "#88a8c0") +
+            lineYs.map((y, i) => {
+                const dx = i % 2 === 0 ? -shift : shift;
+                const x1 = 10 + dx;
+                const x2 = 90 + dx;
+                return `<line x1="${x1}" y1="${y}" x2="${x2}" y2="${y}" stroke="white" stroke-width="3" stroke-linecap="round" opacity="0.75"/>`;
+            }).join("") +
+            tempLabel(temperature)
+        )
+    );
+}
+
+// ─── Exceptional: pulsing warning triangle (4 frames) ────────────────────────
+
+function exceptionalFrames(temperature?: string): string[] {
+    const sizes = [46, 52, 56, 52];
+    return sizes.map(r =>
+        svg(
+            `<defs><radialGradient id="ebg"><stop offset="0%" stop-color="#cc4400"/><stop offset="100%" stop-color="#660000"/></radialGradient></defs>` +
+            `<rect width="144" height="144" fill="url(#ebg)"/>` +
+            `<circle cx="72" cy="60" r="${r}" fill="none" stroke="#ff8800" stroke-width="3" opacity="0.4"/>` +
+            `<polygon points="72,18 118,96 26,96" fill="#ffcc00"/>` +
+            `<polygon points="72,30 110,90 34,90" fill="#ff8800"/>` +
+            `<rect x="68" y="44" width="8" height="28" rx="3" fill="#1a0000"/>` +
+            `<circle cx="72" cy="82" r="5" fill="#1a0000"/>` +
+            tempLabel(temperature)
+        )
+    );
+}
+
+// ─── Default fallback ─────────────────────────────────────────────────────────
+
 function defaultWeather(condition: string, temperature?: string): string {
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
-  <rect width="144" height="144" fill="#446688"/>
-  <text x="72" y="60" text-anchor="middle" fill="white" font-size="13" font-family="Arial,sans-serif" font-weight="bold">${condition}</text>
-  ${tempLabel(temperature)}
-</svg>`;
+    return svg(
+        `<rect width="144" height="144" fill="#446688"/>` +
+        `<text x="72" y="60" text-anchor="middle" fill="white" font-size="13" font-family="Arial,sans-serif" font-weight="bold">${condition}</text>` +
+        tempLabel(temperature)
+    );
 }

--- a/src/plugin/utils/weatherAnimations.ts
+++ b/src/plugin/utils/weatherAnimations.ts
@@ -1,0 +1,469 @@
+/**
+ * Returns an animated SVG string for a given weather condition.
+ * @param condition - The weather entity state (e.g. "sunny", "rainy", "clear-night")
+ * @param temperature - Formatted temperature string (e.g. "22°C"), optional overlay
+ */
+export function getWeatherAnimationSvg(condition: string, temperature?: string): string {
+    switch (condition) {
+        case "sunny": return sunny(temperature);
+        case "clear-night": return clearNight(temperature);
+        case "cloudy": return cloudy(temperature);
+        case "fog": return fog(temperature);
+        case "hail": return hail(temperature);
+        case "lightning": return lightning(temperature);
+        case "lightning-rainy": return lightningRainy(temperature);
+        case "partlycloudy": return partlyCloudy(temperature);
+        case "pouring": return pouring(temperature);
+        case "rainy": return rainy(temperature);
+        case "snowy": return snowy(temperature);
+        case "snowy-rainy": return snowyRainy(temperature);
+        case "windy": return windy(temperature);
+        case "windy-variant": return windyVariant(temperature);
+        case "exceptional": return exceptional(temperature);
+        default: return defaultWeather(condition, temperature);
+    }
+}
+
+function tempLabel(temperature?: string): string {
+    if (!temperature) return "";
+    return `<text x="72" y="136" text-anchor="middle" fill="white" font-size="20" font-family="Arial,sans-serif" font-weight="bold" stroke="#000000" stroke-width="3" paint-order="stroke">${temperature}</text>`;
+}
+
+function cloud(cx: number, cy: number, fill: string): string {
+    return `<ellipse cx="${cx - 18}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>
+  <ellipse cx="${cx}" cy="${cy}" rx="20" ry="16" fill="${fill}"/>
+  <ellipse cx="${cx + 20}" cy="${cy + 8}" rx="16" ry="12" fill="${fill}"/>
+  <rect x="${cx - 33}" y="${cy + 8}" width="69" height="14" fill="${fill}"/>`;
+}
+
+// Sunny: rotating rays + pulsing sun circle on blue sky
+function sunny(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#60b8f0"/>
+      <stop offset="100%" stop-color="#1a7ac4"/>
+    </radialGradient>
+    <radialGradient id="sun" cx="40%" cy="40%">
+      <stop offset="0%" stop-color="#fff8a0"/>
+      <stop offset="100%" stop-color="#ffaa00"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#sky)"/>
+  <g transform="translate(72,56)">
+    <g>
+      <animateTransform attributeName="transform" type="rotate" from="0" to="360" dur="8s" repeatCount="indefinite"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(45)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(90)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(135)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(180)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(225)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(270)"/>
+      <line x1="0" y1="-30" x2="0" y2="-44" stroke="#ffcc00" stroke-width="4" stroke-linecap="round" transform="rotate(315)"/>
+    </g>
+    <circle r="24" fill="url(#sun)">
+      <animate attributeName="r" values="24;27;24" dur="2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Clear night: dark sky, crescent moon, twinkling stars
+function clearNight(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="nightsky" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#1a2f5c"/>
+      <stop offset="100%" stop-color="#050d1a"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#nightsky)"/>
+  <circle cx="22" cy="18" r="2" fill="white"><animate attributeName="opacity" values="1;0.2;1" dur="2.1s" repeatCount="indefinite"/></circle>
+  <circle cx="48" cy="28" r="1.5" fill="white"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
+  <circle cx="102" cy="14" r="2" fill="white"><animate attributeName="opacity" values="1;0.3;1" dur="2.8s" repeatCount="indefinite"/></circle>
+  <circle cx="122" cy="34" r="1.5" fill="white"><animate attributeName="opacity" values="0.7;1;0.7" dur="1.5s" repeatCount="indefinite"/></circle>
+  <circle cx="32" cy="50" r="1" fill="white"><animate attributeName="opacity" values="1;0.4;1" dur="3.2s" repeatCount="indefinite"/></circle>
+  <circle cx="118" cy="52" r="2" fill="white"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/></circle>
+  <circle cx="62" cy="10" r="1.5" fill="white"><animate attributeName="opacity" values="1;0.6;1" dur="1.9s" repeatCount="indefinite"/></circle>
+  <circle cx="85" cy="24" r="1" fill="white"><animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/></circle>
+  <!-- Crescent moon: large lit circle minus offset dark circle -->
+  <circle cx="72" cy="58" r="26" fill="#fffacc"/>
+  <circle cx="84" cy="50" r="22" fill="#1a2f5c"/>
+  <!-- Soft glow ring -->
+  <circle cx="66" cy="62" r="22" fill="none" stroke="#fffacc" stroke-width="2" opacity="0.25">
+    <animate attributeName="r" values="22;27;22" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.25;0.08;0.25" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Cloudy: overcast sky with two drifting cloud layers
+function cloudy(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#6a8aaa"/>
+  <!-- Background cloud, drifts right -->
+  <g opacity="0.55">
+    <animateTransform attributeName="transform" type="translate" values="0,0;10,0;0,0" dur="6s" repeatCount="indefinite"/>
+    ${cloud(50, 68, "#9ab4c8")}
+  </g>
+  <!-- Foreground cloud, drifts left -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0,0;-8,0;0,0" dur="8s" repeatCount="indefinite"/>
+    ${cloud(76, 44, "#dde8f0")}
+  </g>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Fog: light gray with animated horizontal fog bands scrolling
+function fog(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#b0bcc4"/>
+  <rect x="0" y="22" width="200" height="11" rx="5" fill="white" opacity="0.6">
+    <animateTransform attributeName="transform" type="translate" values="0,0;30,0;0,0" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-30" y="40" width="200" height="9" rx="4" fill="white" opacity="0.5">
+    <animateTransform attributeName="transform" type="translate" values="0,0;-26,0;0,0" dur="5s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="57" width="200" height="11" rx="5" fill="white" opacity="0.65">
+    <animateTransform attributeName="transform" type="translate" values="0,0;22,0;0,0" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="75" width="200" height="9" rx="4" fill="white" opacity="0.45">
+    <animateTransform attributeName="transform" type="translate" values="0,0;-32,0;0,0" dur="6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="0" y="92" width="200" height="11" rx="5" fill="white" opacity="0.55">
+    <animateTransform attributeName="transform" type="translate" values="0,0;18,0;0,0" dur="4.5s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-10" y="108" width="200" height="9" rx="4" fill="white" opacity="0.4">
+    <animateTransform attributeName="transform" type="translate" values="0,0;-20,0;0,0" dur="5.5s" repeatCount="indefinite"/>
+  </rect>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Hail: dark storm cloud + animated falling hailstones
+function hail(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#4a6480"/>
+  ${cloud(72, 34, "#708090")}
+  <!-- Hailstones: staggered falling ovals -->
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.4s" begin="0s" repeatCount="indefinite"/>
+    <ellipse cx="40" cy="0" rx="5" ry="4" fill="#d4eeff">
+      <animate attributeName="cy" from="62" to="134" dur="1.4s" begin="0s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.2s" begin="-0.4s" repeatCount="indefinite"/>
+    <ellipse cx="60" cy="0" rx="4" ry="3" fill="#d4eeff">
+      <animate attributeName="cy" from="60" to="134" dur="1.2s" begin="-0.4s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.6s" begin="-0.8s" repeatCount="indefinite"/>
+    <ellipse cx="80" cy="0" rx="5" ry="4" fill="#d4eeff">
+      <animate attributeName="cy" from="62" to="134" dur="1.6s" begin="-0.8s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.3s" begin="-0.2s" repeatCount="indefinite"/>
+    <ellipse cx="100" cy="0" rx="4" ry="3" fill="#d4eeff">
+      <animate attributeName="cy" from="60" to="134" dur="1.3s" begin="-0.2s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.5s" begin="-1.0s" repeatCount="indefinite"/>
+    <ellipse cx="118" cy="0" rx="5" ry="4" fill="#d4eeff">
+      <animate attributeName="cy" from="62" to="134" dur="1.5s" begin="-1.0s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  <g><animate attributeName="opacity" values="1;1;0;1" dur="1.4s" begin="-0.6s" repeatCount="indefinite"/>
+    <ellipse cx="50" cy="0" rx="4" ry="3" fill="#d4eeff">
+      <animate attributeName="cy" from="58" to="134" dur="1.4s" begin="-0.6s" repeatCount="indefinite"/>
+    </ellipse>
+  </g>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Lightning: dark stormy sky + cloud + flashing bolt
+function lightning(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="stormy" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#2a2a4e"/>
+      <stop offset="100%" stop-color="#0a0a1a"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#stormy)"/>
+  ${cloud(72, 32, "#4a4a6a")}
+  <!-- Lightning bolt -->
+  <polygon points="76,54 62,82 72,82 62,110 86,76 74,76 84,54" fill="#ffee00">
+    <animate attributeName="opacity" values="0;0;1;1;0.2;1;0;0;0;0" dur="3s" repeatCount="indefinite"/>
+  </polygon>
+  <!-- Flash effect on background -->
+  <rect width="144" height="144" fill="#fffde0" opacity="0">
+    <animate attributeName="opacity" values="0;0;0.15;0;0;0;0;0;0;0" dur="3s" repeatCount="indefinite"/>
+  </rect>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Lightning-rainy: dark cloud + flashing bolt + rain streaks
+function lightningRainy(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#3a4a5e"/>
+  ${cloud(72, 28, "#505a6a")}
+  <!-- Rain streaks (fast) -->
+  <g opacity="0.8">
+    <line x1="36" y1="0" x2="32" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
+      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="0s" repeatCount="indefinite"/>
+    </line>
+    <line x1="56" y1="0" x2="52" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
+      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.2s" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.2s" repeatCount="indefinite"/>
+    </line>
+    <line x1="96" y1="0" x2="92" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
+      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.4s" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.4s" repeatCount="indefinite"/>
+    </line>
+    <line x1="116" y1="0" x2="112" y2="16" stroke="#80aadd" stroke-width="2" stroke-linecap="round">
+      <animate attributeName="y1" from="52" to="120" dur="0.6s" begin="-0.1s" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="68" to="136" dur="0.6s" begin="-0.1s" repeatCount="indefinite"/>
+    </line>
+  </g>
+  <!-- Lightning bolt -->
+  <polygon points="76,50 63,76 72,76 62,100 84,70 73,70 82,50" fill="#ffee00">
+    <animate attributeName="opacity" values="0;0;1;1;0.3;1;0;0;0;0" dur="2.5s" repeatCount="indefinite"/>
+  </polygon>
+  <rect width="144" height="144" fill="#fffde0" opacity="0">
+    <animate attributeName="opacity" values="0;0;0.12;0;0;0;0;0;0;0" dur="2.5s" repeatCount="indefinite"/>
+  </rect>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Partly cloudy: blue sky, sun at back, cloud drifting in front
+function partlyCloudy(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="partsky" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#60b8f0"/>
+      <stop offset="100%" stop-color="#2a8ad4"/>
+    </radialGradient>
+    <radialGradient id="partsun" cx="40%" cy="40%">
+      <stop offset="0%" stop-color="#fff8a0"/>
+      <stop offset="100%" stop-color="#ffaa00"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#partsky)"/>
+  <!-- Sun (behind cloud) -->
+  <circle cx="48" cy="48" r="22" fill="url(#partsun)">
+    <animate attributeName="r" values="22;25;22" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Short sun rays -->
+  <g transform="translate(48,48)">
+    <animateTransform attributeName="transform" type="rotate" from="0 48 48" to="360 48 48" dur="10s" repeatCount="indefinite" additive="replace"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(60 0 0)"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(120 0 0)"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(180 0 0)"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(240 0 0)"/>
+    <line x1="0" y1="-28" x2="0" y2="-36" stroke="#ffcc00" stroke-width="3" stroke-linecap="round" transform="rotate(300 0 0)"/>
+  </g>
+  <!-- Cloud in front -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="0,0;6,0;0,0" dur="7s" repeatCount="indefinite"/>
+    ${cloud(82, 52, "#e8f2fa")}
+  </g>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Pouring: dark cloud + many fast heavy rain streaks
+function pouring(temperature?: string): string {
+    const rainLine = (x: number, delay: string) =>
+        `<line x1="${x}" y1="0" x2="${x - 4}" y2="18" stroke="#80aadd" stroke-width="2.5" stroke-linecap="round">
+      <animate attributeName="y1" from="54" to="120" dur="0.5s" begin="${delay}" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="72" to="138" dur="0.5s" begin="${delay}" repeatCount="indefinite"/>
+    </line>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#3a4e62"/>
+  ${cloud(72, 30, "#586070")}
+  ${rainLine(30, "0s")}
+  ${rainLine(46, "-0.1s")}
+  ${rainLine(62, "-0.2s")}
+  ${rainLine(78, "-0.3s")}
+  ${rainLine(94, "-0.4s")}
+  ${rainLine(110, "-0.15s")}
+  ${rainLine(38, "-0.35s")}
+  ${rainLine(54, "-0.45s")}
+  ${rainLine(70, "-0.05s")}
+  ${rainLine(86, "-0.25s")}
+  ${rainLine(102, "-0.4s")}
+  ${rainLine(118, "-0.1s")}
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Rainy: overcast sky, cloud, moderate falling rain
+function rainy(temperature?: string): string {
+    const rainLine = (x: number, delay: string) =>
+        `<line x1="${x}" y1="0" x2="${x - 3}" y2="14" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
+      <animate attributeName="y1" from="56" to="124" dur="0.9s" begin="${delay}" repeatCount="indefinite"/>
+      <animate attributeName="y2" from="70" to="138" dur="0.9s" begin="${delay}" repeatCount="indefinite"/>
+    </line>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#5a7090"/>
+  ${cloud(72, 34, "#7080a0")}
+  ${rainLine(36, "0s")}
+  ${rainLine(56, "-0.3s")}
+  ${rainLine(76, "-0.6s")}
+  ${rainLine(96, "-0.15s")}
+  ${rainLine(116, "-0.45s")}
+  ${rainLine(46, "-0.75s")}
+  ${rainLine(66, "-0.5s")}
+  ${rainLine(86, "-0.2s")}
+  ${rainLine(106, "-0.8s")}
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Snowy: light blue sky, cloud, snowflakes falling and spinning
+function snowy(temperature?: string): string {
+    const flake = (x: number, delay: string, size: number) =>
+        `<text x="${x}" y="0" font-size="${size}" fill="white" text-anchor="middle" opacity="0.9">❄
+      <animate attributeName="y" from="56" to="138" dur="2s" begin="${delay}" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2s" begin="${delay}" repeatCount="indefinite"/>
+    </text>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#7090b4"/>
+  ${cloud(72, 32, "#90a8be")}
+  ${flake(32, "0s", 14)}
+  ${flake(54, "-0.5s", 12)}
+  ${flake(74, "-1.0s", 14)}
+  ${flake(94, "-1.5s", 12)}
+  ${flake(114, "-0.7s", 14)}
+  ${flake(44, "-1.2s", 11)}
+  ${flake(64, "-0.3s", 13)}
+  ${flake(84, "-1.7s", 11)}
+  ${flake(104, "-0.9s", 12)}
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Snowy-rainy: mix of rain streaks and snowflakes
+function snowyRainy(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#607888"/>
+  ${cloud(72, 30, "#7888a0")}
+  <!-- Rain streaks -->
+  <line x1="36" y1="0" x2="33" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
+    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="0s" repeatCount="indefinite"/>
+    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="72" y1="0" x2="69" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
+    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="-0.3s" repeatCount="indefinite"/>
+    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="-0.3s" repeatCount="indefinite"/>
+  </line>
+  <line x1="108" y1="0" x2="105" y2="12" stroke="#7090c0" stroke-width="2" stroke-linecap="round">
+    <animate attributeName="y1" from="54" to="120" dur="0.8s" begin="-0.6s" repeatCount="indefinite"/>
+    <animate attributeName="y2" from="66" to="132" dur="0.8s" begin="-0.6s" repeatCount="indefinite"/>
+  </line>
+  <!-- Snowflakes -->
+  <text x="54" y="0" font-size="13" fill="white" text-anchor="middle" opacity="0.9">❄
+    <animate attributeName="y" from="58" to="134" dur="2.2s" begin="-0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-0.4s" repeatCount="indefinite"/>
+  </text>
+  <text x="90" y="0" font-size="12" fill="white" text-anchor="middle" opacity="0.9">❄
+    <animate attributeName="y" from="60" to="134" dur="2.2s" begin="-1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-1.2s" repeatCount="indefinite"/>
+  </text>
+  <text x="36" y="0" font-size="11" fill="white" text-anchor="middle" opacity="0.9">❄
+    <animate attributeName="y" from="58" to="134" dur="2.2s" begin="-1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-1.8s" repeatCount="indefinite"/>
+  </text>
+  <text x="112" y="0" font-size="13" fill="white" text-anchor="middle" opacity="0.9">❄
+    <animate attributeName="y" from="60" to="134" dur="2.2s" begin="-0.9s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.9;0;0.9" dur="2.2s" begin="-0.9s" repeatCount="indefinite"/>
+  </text>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Windy: blue sky with animated arcing wind streaks scrolling left
+function windy(temperature?: string): string {
+    const windArc = (y: number, width: number, dur: string, begin: string) =>
+        `<path d="M160,${y} Q110,${y - 8} 60,${y} Q10,${y + 8} -40,${y}" fill="none" stroke="white" stroke-width="${width}" stroke-linecap="round" opacity="0.7">
+      <animateTransform attributeName="transform" type="translate" values="0,0;-200,0" dur="${dur}" begin="${begin}" repeatCount="indefinite"/>
+    </path>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="windsky" cx="50%" cy="30%">
+      <stop offset="0%" stop-color="#70c0f0"/>
+      <stop offset="100%" stop-color="#2a90d4"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#windsky)"/>
+  ${windArc(28, 3.5, "1.8s", "0s")}
+  ${windArc(44, 2.5, "2.2s", "-0.4s")}
+  ${windArc(60, 3.5, "1.9s", "-0.8s")}
+  ${windArc(76, 2.5, "2.4s", "-1.2s")}
+  ${windArc(92, 3, "1.7s", "-0.6s")}
+  ${windArc(108, 2.5, "2.1s", "-1.5s")}
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Windy-variant: cloud + wind streaks
+function windyVariant(temperature?: string): string {
+    const windLine = (y: number, x1: number, x2: number, delay: string) =>
+        `<line x1="${x1}" y1="${y}" x2="${x2}" y2="${y}" stroke="white" stroke-width="3" stroke-linecap="round" opacity="0.7">
+      <animateTransform attributeName="transform" type="translate" values="0,0;-20,0;0,0" dur="1.8s" begin="${delay}" repeatCount="indefinite"/>
+    </line>`;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#6090b0"/>
+  ${cloud(72, 34, "#88a8c0")}
+  ${windLine(68, 10, 70, "0s")}
+  ${windLine(80, 20, 90, "-0.3s")}
+  ${windLine(92, 8, 80, "-0.6s")}
+  ${windLine(104, 24, 100, "-0.9s")}
+  ${windLine(116, 12, 72, "-0.4s")}
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Exceptional: red/orange background, pulsing warning triangle
+function exceptional(temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <defs>
+    <radialGradient id="exceptbg" cx="50%" cy="50%">
+      <stop offset="0%" stop-color="#cc4400"/>
+      <stop offset="100%" stop-color="#660000"/>
+    </radialGradient>
+  </defs>
+  <rect width="144" height="144" fill="url(#exceptbg)"/>
+  <!-- Pulsing outer ring -->
+  <circle cx="72" cy="60" r="46" fill="none" stroke="#ff8800" stroke-width="3" opacity="0.5">
+    <animate attributeName="r" values="46;54;46" dur="1.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.5;0.1;0.5" dur="1.5s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Warning triangle -->
+  <polygon points="72,18 118,96 26,96" fill="#ffcc00">
+    <animate attributeName="opacity" values="1;0.6;1" dur="1.5s" repeatCount="indefinite"/>
+  </polygon>
+  <polygon points="72,30 110,90 34,90" fill="#ff8800"/>
+  <!-- Exclamation mark -->
+  <rect x="68" y="44" width="8" height="28" rx="3" fill="#1a0000"/>
+  <circle cx="72" cy="82" r="5" fill="#1a0000"/>
+  ${tempLabel(temperature)}
+</svg>`;
+}
+
+// Default fallback: neutral background with condition text
+function defaultWeather(condition: string, temperature?: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144">
+  <rect width="144" height="144" fill="#446688"/>
+  <text x="72" y="60" text-anchor="middle" fill="white" font-size="13" font-family="Arial,sans-serif" font-weight="bold">${condition}</text>
+  ${tempLabel(temperature)}
+</svg>`;
+}


### PR DESCRIPTION
## Summary
- Adds `src/plugin/utils/weatherAnimations.ts` with SMIL-animated SVG for all 15 HA weather conditions: `sunny`, `clear-night`, `cloudy`, `fog`, `hail`, `lightning`, `lightning-rainy`, `partlycloudy`, `pouring`, `rainy`, `snowy`, `snowy-rainy`, `windy`, `windy-variant`, `exceptional`
- Updates `WeatherDisplayAction` to call `setImage(svg)` instead of `setTitle(text)` — the image now contains both the animation and temperature label
- Adds `formatTemperatureLabel` to `weatherUtils.ts` (existing `formatWeatherTitle` preserved for tests)

## Test plan
- [ ] All 148 existing tests pass (`npm test`)
- [ ] Manually verify each weather condition displays the correct animation on a Stream Deck key
- [ ] Confirm temperature value and unit overlay is visible on the animated image
- [ ] Confirm the disconnected state (grey SVG) still overrides weather images correctly

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)